### PR TITLE
Add memory usage for current PID

### DIFF
--- a/rubytrickz.rb
+++ b/rubytrickz.rb
@@ -5,6 +5,7 @@ class Rubytrickz
 
   count = 1
   puts "My PID is #{Process.pid}"
+  puts "My PID is using #{`ps -o rss= -p #{Process.pid}`.to_i/1024} MB of memory"
   puts DATA.read
   puts
 


### PR DESCRIPTION
Adds a shell command we can use to check to current memory usage of a ruby process.
